### PR TITLE
fix(dev): disable Recipe Json snippet

### DIFF
--- a/kubejs/config/probejs.json
+++ b/kubejs/config/probejs.json
@@ -5,7 +5,7 @@
   "allowRegistryObjectDumps": false,
   "requireSingleAndPerm": true,
   "enabled": true,
-  "disableRecipeJsonDump": false,
+  "disableRecipeJsonDump": true,
   "dumpJSONIntermediates": false,
   "version": 1
 }


### PR DESCRIPTION
默认情况下probejs会把所有合成表数据导出到vscode的snippets里，开发时各种`#`开头的`#some_namespace:some/recipe/path`就是合成表导出的结果。但是CTI里合成表实在太多，导出合成表snippet会导致开发时有非常非常严重的输入延迟（因为每输入一个字符vscode都需要在snippets里匹配一次）

注：需要重新生成snippet（`/probejs dump`）